### PR TITLE
[FIX] history_duplicate_error

### DIFF
--- a/src/main/java/com/banghyang/history/entity/History.java
+++ b/src/main/java/com/banghyang/history/entity/History.java
@@ -26,7 +26,7 @@ public class History {
     @JoinColumn(name = "member_id")
     private Member member; // 히스토리 생성 사용자 아이디
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "line_id", referencedColumnName = "id", nullable = false)
     @JsonBackReference
     private Line line; // 히스토리 생성한 추천의 계열 아이디

--- a/src/main/java/com/banghyang/history/entity/History.java
+++ b/src/main/java/com/banghyang/history/entity/History.java
@@ -28,7 +28,6 @@ public class History {
 
     @ManyToOne
     @JoinColumn(name = "line_id", referencedColumnName = "id", nullable = false)
-    @JsonBackReference
     private Line line; // 히스토리 생성한 추천의 계열 아이디
 
     // 생성시간 자동 입력


### PR DESCRIPTION
@History_entity
- one to one 을 통해 fk 이지만 유니크 값이 되어 중복이 허용되지 않은 부분을
- ManyToOne 로 수정함
- one to one 의 순환 참조를 막는 JsonBackReference 를 삭제